### PR TITLE
API 응답 모델 추가 (#1, #3, #4)

### DIFF
--- a/lib/models/api/user_auth.dart
+++ b/lib/models/api/user_auth.dart
@@ -1,0 +1,23 @@
+class UserAuthResponse {
+  final String accessToken;
+  final String refreshToken;
+
+  UserAuthResponse({
+    required this.accessToken,
+    required this.refreshToken
+  });
+
+  factory UserAuthResponse.fromJson(Map<String, dynamic> json) {
+    return UserAuthResponse(
+      accessToken: json['access_token'],
+      refreshToken: json['refresh_token']
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['access_token'] = accessToken;
+    data['refresh_token'] = refreshToken;
+    return data;
+  }
+}

--- a/lib/models/api/user_auth_refresh.dart
+++ b/lib/models/api/user_auth_refresh.dart
@@ -1,0 +1,19 @@
+class UserAuthRefreshResponse {
+  final String accessToken;
+
+  UserAuthRefreshResponse({
+    required this.accessToken
+  });
+
+  factory UserAuthRefreshResponse.fromJson(Map<String, dynamic> json) {
+    return UserAuthRefreshResponse(
+      accessToken: json['access_token']
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['access_token'] = accessToken;
+    return data;
+  }
+}

--- a/lib/models/api/user_create.dart
+++ b/lib/models/api/user_create.dart
@@ -18,11 +18,11 @@ class UserCreateResponse {
   factory UserCreateResponse.fromJson(Map<String, dynamic> json) {
     return UserCreateResponse(
       error: json['error'],
-      email: json['email'],
-      password: json['password'],
-      username: json['username'],
-      phone: json['phone'],
-      birth: json['birth'],
+      email: json['email'] ?? false,
+      password: json['password'] ?? false,
+      username: json['username'] ?? false,
+      phone: json['phone'] ?? false,
+      birth: json['birth'] ?? false,
     );
   }
 

--- a/lib/models/api/user_create.dart
+++ b/lib/models/api/user_create.dart
@@ -1,0 +1,39 @@
+class UserCreateResponse {
+  final String error;
+  final bool email;
+  final bool password;
+  final bool username;
+  final bool phone;
+  final bool birth;
+
+  UserCreateResponse({
+    required this.error,
+    required this.email,
+    required this.password,
+    required this.username,
+    required this.phone,
+    required this.birth
+  });
+
+  factory UserCreateResponse.fromJson(Map<String, dynamic> json) {
+    return UserCreateResponse(
+      error: json['error'],
+      email: json['email'],
+      password: json['password'],
+      username: json['username'],
+      phone: json['phone'],
+      birth: json['birth'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['error'] = error;
+    data['email'] = email;
+    data['password'] = password;
+    data['username'] = username;
+    data['phone'] = phone;
+    data['birth'] = birth;
+    return data;
+  }
+}

--- a/lib/models/api/user_read.dart
+++ b/lib/models/api/user_read.dart
@@ -1,0 +1,43 @@
+class UserReadResponse {
+  final String email;
+  final String username;
+  final String phone;
+  final String birth;
+  final String profileUrl;
+  final int level;
+  final List<String> sns;
+
+  UserReadResponse({
+    required this.email,
+    required this.username,
+    required this.phone,
+    required this.birth,
+    required this.profileUrl,
+    required this.level,
+    required this.sns
+  });
+
+  factory UserReadResponse.fromJson(Map<String, dynamic> json) {
+    return UserReadResponse(
+      email: json['email'],
+      username: json['username'],
+      phone: json['phone'],
+      birth: json['birth'],
+      profileUrl: json['profile_url'],
+      level: json['level'],
+      sns: json['sns'].cast<String>()
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['email'] = email;
+    data['username'] = username;
+    data['phone'] = phone;
+    data['birth'] = birth;
+    data['profile_url'] = profileUrl;
+    data['level'] = level;
+    data['sns'] = sns;
+    return data;
+  }
+}

--- a/lib/models/api/user_update.dart
+++ b/lib/models/api/user_update.dart
@@ -1,0 +1,39 @@
+class UserUpdateResponse {
+  final String error;
+  final bool email;
+  final bool password;
+  final bool username;
+  final bool phone;
+  final bool birth;
+
+  UserUpdateResponse({
+    required this.error,
+    required this.email,
+    required this.password,
+    required this.username,
+    required this.phone,
+    required this.birth
+  });
+
+  factory UserUpdateResponse.fromJson(Map<String, dynamic> json) {
+    return UserUpdateResponse(
+      error: json['error'],
+      email: json['email'],
+      password: json['password'],
+      username: json['username'],
+      phone: json['phone'],
+      birth: json['birth'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['error'] = error;
+    data['email'] = email;
+    data['password'] = password;
+    data['username'] = username;
+    data['phone'] = phone;
+    data['birth'] = birth;
+    return data;
+  }
+}

--- a/lib/models/api/user_update.dart
+++ b/lib/models/api/user_update.dart
@@ -18,11 +18,11 @@ class UserUpdateResponse {
   factory UserUpdateResponse.fromJson(Map<String, dynamic> json) {
     return UserUpdateResponse(
       error: json['error'],
-      email: json['email'],
-      password: json['password'],
-      username: json['username'],
-      phone: json['phone'],
-      birth: json['birth'],
+      email: json['email'] ?? false,
+      password: json['password'] ?? false,
+      username: json['username'] ?? false,
+      phone: json['phone'] ?? false,
+      birth: json['birth'] ?? false,
     );
   }
 

--- a/lib/models/api/user_update.dart
+++ b/lib/models/api/user_update.dart
@@ -1,6 +1,5 @@
 class UserUpdateResponse {
   final String error;
-  final bool email;
   final bool password;
   final bool username;
   final bool phone;
@@ -8,7 +7,6 @@ class UserUpdateResponse {
 
   UserUpdateResponse({
     required this.error,
-    required this.email,
     required this.password,
     required this.username,
     required this.phone,
@@ -18,7 +16,6 @@ class UserUpdateResponse {
   factory UserUpdateResponse.fromJson(Map<String, dynamic> json) {
     return UserUpdateResponse(
       error: json['error'],
-      email: json['email'] ?? false,
       password: json['password'] ?? false,
       username: json['username'] ?? false,
       phone: json['phone'] ?? false,
@@ -29,7 +26,6 @@ class UserUpdateResponse {
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
     data['error'] = error;
-    data['email'] = email;
     data['password'] = password;
     data['username'] = username;
     data['phone'] = phone;


### PR DESCRIPTION
## Summary
User API 응답 모델을 추가했습니다.

## Description
auth, token refresh, create, read, update 에 대한 모델을 추가했습니다.
null check를 추가하고, 필요없는 속성을 제거했습니다.
경로는 <code>lib/models/api</code> 입니다.
API 요청 후 json응답은 이 모델들로 컨버팅됩니다.

close #1 #3 #4 